### PR TITLE
Load services and extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,8 @@ typings/
 # application
 tests/
 
+# idea
+.vscode
+.idea
+.theia
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/cli",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/cli",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Most Web Framework command line utility",
   "homepage": "https://github.com/kbarbounakis/most-web-cli",
   "repository": {


### PR DESCRIPTION
This MR closes #7 by registering application services and extensions while initializing application sandbox.

If application services are not required by application sandbox set `disableServices` option in `.themost-cli.json`
```
{
    "base":"server",
    "out": "dist/server",
    "disableServices": true
}
```
Note: The default value is false.


If application extensions are not required by application sandbox -they don't affect application data operations- set `disableExtensions` option to true in `.themost-cli.json`
```
{
    "base":"server",
    "out": "dist/server",
    "disableExtensions": true
}
```
Note: The default value is false.